### PR TITLE
fix: allow partial persist states

### DIFF
--- a/.changeset/eighty-deers-switch.md
+++ b/.changeset/eighty-deers-switch.md
@@ -1,0 +1,5 @@
+---
+'zustand-x': patch
+---
+
+Support partial state objects in the persist typings

--- a/packages/zustand-x/src/types/CreateStoreOptions.ts
+++ b/packages/zustand-x/src/types/CreateStoreOptions.ts
@@ -23,5 +23,5 @@ export interface CreateStoreOptions<T extends State> {
   /**
    * Persist middleware options.
    */
-  persist?: PersistOptions<T>;
+  persist?: PersistOptions<Partial<T>>;
 }


### PR DESCRIPTION
**Description**

See changesets.

Zustand's persist middleware supports persisting partial state (https://docs.pmnd.rs/zustand/integrations/persisting-store-data#partialize). This PR adjusts the typing to allow this.