### PR TITLE
Draft: Update Persist's partialize return type

### DIFF
--- a/packages/zustand-x/src/middlewares/persist.ts
+++ b/packages/zustand-x/src/middlewares/persist.ts
@@ -4,5 +4,5 @@ import { MiddlewareOption } from '../types';
 
 export { persist as persistMiddleware } from 'zustand/middleware';
 export type PersistOptions<StateType> = MiddlewareOption<
-  Partial<_PersistOptions<StateType>>
+  Partial<_PersistOptions<StateType, Partial<StateType>>>
 >;


### PR DESCRIPTION
**Description**

I noticed when using the partialize option from Zustand that we expect to return the whole store type.

Since we're partializing, and picking what we want to persist, we will always be returning a partial version of the store.

I have updated the type to reflect this
